### PR TITLE
Updates to manage Sentinel runtime config.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,8 +53,8 @@ class redis (
 
   # Lay down intermediate config file and copy it in with a 'cp' exec resource.
   # Redis rewrites its config file with additional state information so we only
-  # want to do this the first time redis starts so we can at least get it daemonized
-  # and assign a master node if applicable.
+  # want to do this the first time redis starts so we can at least get it 
+  # daemonized and assign a master node if applicable.
   file { '/etc/redis.conf.puppet':
     ensure  => present,
     owner   => redis,
@@ -97,8 +97,7 @@ class redis (
   exec { 'configure_redis':
     command     => $config_script,
     refreshonly => true,
-    require     => [ Service['redis'],
-                     File[$config_script] ],
+    require     => [ Service['redis'], File[$config_script] ],
   }
 
   # In an HA setup we choose to only persist data to disk on

--- a/templates/sentinel.conf.erb
+++ b/templates/sentinel.conf.erb
@@ -34,15 +34,6 @@ dir /tmp
 #
 # Note: master name should not include special characters or spaces.
 # The valid charset is A-z 0-9 and the three characters ".-_".
-<% if @redis_clusters.respond_to?(:key?) -%>
-<% @redis_clusters.each_key { |master| -%>
-sentinel monitor <%= master %> <%= @redis_clusters[master]['master_ip'] %> 6379 2
-sentinel down-after-milliseconds <%= master %> <%= @redis_clusters[master]['down_after'] %>
-sentinel parallel-syncs <%= master %> 1
-sentinel failover-timeout <%= master %> <%= @redis_clusters[master]['failover_timeout'] %>
-#sentinel notification-script mymaster /var/redis/notify.sh
-<% } %>
-<% end -%>
 
 # sentinel auth-pass <master-name> <password>
 #

--- a/templates/sentinel_config.sh.erb
+++ b/templates/sentinel_config.sh.erb
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+# redis_config.sh
+#
+# Set runtime configuration for redis instance because
+# managing the config file is just about impossible.
+#
+sentinel_cli='/usr/bin/redis-cli -p 26379'
+sentinel_state=$(${sentinel_cli} ping)
+
+if ! echo "${sentinel_state}" | grep -i pong  > /dev/null;
+then
+  echo "Sentinel state check failed. Exiting."
+  exit
+fi
+
+<% if @redis_clusters.respond_to?(:key) -%>
+<%   @redis_clusters.each_key { |k| -%>
+${sentinel_cli} sentinel  monitor <%= k %> <%= @redis_clusters[k]['master_ip'] %> 6379 2 
+<%     if @redis_clusters[k]['down_after'] -%>
+${sentinel_cli} sentinel set <%= k %> down-after-milliseconds <%= @redis_clusters[k]['down_after'] %>
+<%     end -%>
+<%     if @redis_clusters[k]['failover_timeout'] -%>
+${sentinel_cli} sentinel set <%= k %> failover-timeout <%= @redis_clusters[k]['failover_timeout'] %>
+<%     end -%>
+<%   } -%>
+<% end -%>


### PR DESCRIPTION
Was writing the sentinel config to a temp file and copying in place
but this causes the sentinel instances to lose track of the information
they've gleaned from the running cluster and written to disk.
With Puppet runs being sporadic this is really bad.
