### PR TITLE
Make the sentinel service name a parameter.

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -27,6 +27,7 @@
 #
 class redis::sentinel (
   $version        = 'installed',
+  $service_name   = 'sentinel',
   $redis_clusters = undef,
 ) {
 
@@ -57,11 +58,11 @@ class redis::sentinel (
   exec { 'cp_sentinel_conf':
     command     => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf',
     refreshonly => true,
-    notify      => Service[sentinel],
+    notify      => Service[$service_name],
   }
 
   # Run it!
-  service { 'sentinel':
+  service { $service_name:
     ensure     => running,
     enable     => true,
     hasrestart => true,
@@ -86,7 +87,7 @@ class redis::sentinel (
   exec { 'configure_sentinel':
     command     => $config_script,
     refreshonly => true,
-    require     => [ Service['sentinel'], File[$config_script] ],
+    require     => [ Service[$service_name], File[$config_script] ],
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-redis",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Redis and Sentinel config management.",


### PR DESCRIPTION
We're switching to a different package layout and the sentinel service
is now known as redis-sentinel.  The default is unchanged so there are
no compatibility issues.
