### PR TITLE
Support sentinel quorum and redis slave priority

### DIFF
--- a/templates/sentinel_config.sh.erb
+++ b/templates/sentinel_config.sh.erb
@@ -16,7 +16,7 @@ fi
 
 <% if @redis_clusters.respond_to?(:key) -%>
 <%   @redis_clusters.each_key { |k| -%>
-${sentinel_cli} sentinel  monitor <%= k %> <%= @redis_clusters[k]['master_ip'] %> 6379 2 
+${sentinel_cli} sentinel monitor <%= k %> <%= @redis_clusters[k]['master_ip'] %> 6379 <%= @redis_clusters[k]['quorum'] || 2 %>
 <%     if @redis_clusters[k]['down_after'] -%>
 ${sentinel_cli} sentinel set <%= k %> down-after-milliseconds <%= @redis_clusters[k]['down_after'] %>
 <%     end -%>


### PR DESCRIPTION
This is a surprisingly simple PR, but I recognize that it is not the best way to do it. Setting configuration defaults in erb templates is like hiding them.  Comments suggested, however in the meantime here's how I've managed to use this with hieradata.

For redis, this just works.

```
redis::config:
  save: ''
  dir: '/var/lib/redis/'
  appendonly: 'yes'
  appendfsync: 'everysec'
  slave-priority: 0
```

For sentinel, I had to change the default from '2' in the erb template

```
redis::sentinel::redis_clusters:
  'vagrant':
    master_ip: '192.168.33.10'
    down_after: 30000,
    failover_timeout: 180000
    quorum: 3
```
