### PR TITLE
Bump metadata version to v0.2.4

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-redis",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Redis and Sentinel config management.",


### PR DESCRIPTION
I missed the metadata version in PR #8. I need to this to build the correct tarball version for the forge.
