### PR TITLE
Update resource dependencies so we only copy in the inital config once.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,2 @@
+* Thu Aug 18 2016 Dan Sajner <dsajner@covermymeds.com> - 1.0.0
+- BREAKING CHANGE: Introduces a semaphore file to enforce the one-time copy of initial redis and sentinel config files.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,13 +62,13 @@ class redis (
     mode    => '0644',
     content => template('redis/redis.conf.puppet.erb'),
     require => Package['redis'],
-    notify  => Exec['cp_redis_config'],
   }
 
   exec { 'cp_redis_config':
-    command     => '/bin/cp -p /etc/redis.conf.puppet /etc/redis.conf',
-    refreshonly => true,
-    notify      => Service[redis],
+    command => '/bin/cp -p /etc/redis.conf.puppet /etc/redis.conf; /bin/touch /etc/redis.conf.copied',
+    creates => '/etc/redis.conf.copied',
+    require => File['/etc/redis.conf.puppet'],
+    notify  => Service[redis],
   }
 
   # Run it!

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class redis (
   }
 
   exec { 'cp_redis_config':
-    command => '/bin/cp -p /etc/redis.conf.puppet /etc/redis.conf; /bin/touch /etc/redis.conf.copied',
+    command => '/bin/cp -p /etc/redis.conf.puppet /etc/redis.conf && /bin/touch /etc/redis.conf.copied',
     creates => '/etc/redis.conf.copied',
     require => File['/etc/redis.conf.puppet'],
     notify  => Service[redis],

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -54,7 +54,7 @@ class redis::sentinel (
   }
 
   exec { 'cp_sentinel_conf':
-    command => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf; /bin/touch /etc/sentinel.conf.copied',
+    command => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf && /bin/touch /etc/sentinel.conf.copied',
     creates => '/etc/sentinel.conf.copied',
     notify  => Service['sentinel'],
     require => File['/etc/sentinel.conf.puppet'],

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -51,13 +51,13 @@ class redis::sentinel (
     mode    => '0644',
     content => template('redis/sentinel.conf.erb'),
     require => Package['redis'],
-    notify  => Exec['cp_sentinel_conf'],
   }
 
   exec { 'cp_sentinel_conf':
-    command     => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf',
-    refreshonly => true,
-    notify      => Service[sentinel],
+    command => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf; /bin/touch /etc/sentinel.conf.copied',
+    creates => '/etc/sentinel.conf.copied',
+    notify  => Service['sentinel'],
+    require => File['/etc/sentinel.conf.puppet'],
   }
 
   # Run it!

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-redis",
-  "version": "0.2.4",
+  "version": "1.0.0",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Redis and Sentinel config management.",


### PR DESCRIPTION
The original intent was that a customizable config could be laid down on initial provision so that you can make a redis instance a slave via puppet.  From that point on config is managed via the runtime script and/or sentinel HA.  

I intend to remove our use of the `redis::slaveof` parameter in favor of an ansible playbook that will complete the one-time configuration tasks that need to happen when we build a new cluster.  We'll also have to push out the semaphore file to all systems so that the exec only runs on new systems.  
