### PR TITLE
Update the default directory for redis

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-redis",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Redis and Sentinel config management.",

--- a/templates/redis.conf.puppet.erb
+++ b/templates/redis.conf.puppet.erb
@@ -184,7 +184,7 @@ dbfilename dump.rdb
 # The Append Only File will also be created inside this directory.
 # 
 # Note that you must specify a directory here, not a file name.
-dir ./
+dir "/var/lib/redis"
 
 ################################# REPLICATION #################################
 


### PR DESCRIPTION
We change this configuration to `/var/lib/redis` in our use case so I'm making this the default.
