### PR TITLE
make redis and sentinel a bit more flexible

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,4 @@
 * Thu Aug 18 2016 Dan Sajner <dsajner@covermymeds.com> - 1.0.0
 - BREAKING CHANGE: Introduces a semaphore file to enforce the one-time copy of initial redis and sentinel config files.
+* Thu May 18 2017 Doug Morris <dmorris@covermymeds.com> - 2.0.0
+- BREAKING CHANGE: Introduces "protected-mode" configuration option, which will break pre 3.2.0 redis releases.  Also these changes require puppet version => 4.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,5 @@ class { 'sentinel':
 # Notes
 The service definition is only dependent on the package so Redis may start with the configuration installed via your package.  The initial config file overlay will notify the Redis server to restart so upon initial installation Redis may start and then restart with updated configs.  In testing this has not presented any issues.
 
-
-
-
+Beginning with redis version 3.2, if you do not assign an IP to redis using the 'bind' configuration option, redis will only allow connections from localhost(127.0.0.1).  The configuration defaults to 'protected-mode yes', in order to have redis accept connections without setting 'bind', 'protected-mode' must be set to 'no'.  This could be considered a breaking change, if you have the 'protected-mode' specified in a configuration file when using a version before 3.2, redis
+will not start.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,7 +43,7 @@ class redis (
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version =~ /^3.2.*/ ) or ( $version == 'installed' ) {
+  if ( versioncmp( $version, '3.2' ) >= 0 ) or ( $version == 'installed' ) {
     if ( $protected != "disabled" ) {
       $config_32 = $protected
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,7 +29,7 @@ class redis (
   $config             = {},
   $manage_persistence = false,
   $slaveof            = undef,
-  $version            = 'redis-3.0.5-1.el7.cmm.x86_64',
+  $version            = 'installed',
   $packages           = ['redis'],
   $redis_conf         = '/etc/redis.conf',
   $redis_service      = 'redis',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 # $version: The package version of Redis you want to install
 # $packages: The packages needed to install redis
 # $redis_conf: The configuration file for redis
-# $redis_service: The serivce to run for redis
+# $service_name: The serivce to run for redis
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
 # or specifically bind to an address, if you are using an earlier
 # version of redis and "installed" as your version you can use "protected = disabled"
@@ -34,9 +34,9 @@ class redis (
   $manage_persistence   = false,
   $slaveof              = undef,
   $packages             = ['redis'],
-  String $protected     = 'no',
+  String $protected     = 'yes',
   String $redis_conf    = '/etc/redis.conf',
-  String $redis_service = 'redis',
+  String $service_name  = 'redis',
   String $version       = 'installed',
 ) {
 
@@ -86,11 +86,11 @@ class redis (
     command => "/bin/cp -p ${redis_conf}.puppet ${redis_conf} && /bin/touch ${redis_conf}.copied",
     creates => "${redis_conf}.copied",
     require => File["${redis_conf}.puppet"],
-    notify  => Service[$redis_service],
+    notify  => Service[$service_name],
   }
 
   # Run it!
-  service { $redis_service:
+  service { $service_name:
     ensure     => running,
     enable     => true,
     hasrestart => true,
@@ -122,7 +122,7 @@ class redis (
   exec { 'configure_redis':
     command     => $config_script,
     refreshonly => true,
-    require     => [ Service[$redis_service], File[$config_script] ],
+    require     => [ Service[$service_name], File[$config_script] ],
   }
 
   # In an HA setup we choose to only persist data to disk on

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,8 +9,8 @@
 # $slaveof: IP address of the initial master Redis server 
 # $version: The package version of Redis you want to install
 # $packages: The packages needed to install redis
-# $redis_conf: The configuration file for resis
-# $redis_service: The serivce to run for resis
+# $redis_conf: The configuration file for redis
+# $redis_service: The serivce to run for redis
 #
 # === Examples
 #
@@ -31,8 +31,8 @@ class redis (
   $slaveof            = undef,
   $version            = 'installed',
   $packages           = ['redis']
-  $redis_conf         = undef,
-  $redis_service      = undef,
+  $redis_conf         = 'redis.conf',
+  $redis_service      = 'redis.service',
 ) {
 
   # Install the redis package

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,9 @@
 # $packages: The packages needed to install redis
 # $redis_conf: The configuration file for redis
 # $redis_service: The serivce to run for redis
+# $protected - As of version 3.2 you need to set proteced-mode yes or no
+# or specifically bind to an address, you can use disabled here if your
+# versions is "installed"
 #
 # === Examples
 #
@@ -29,18 +32,21 @@ class redis (
   $config               = {},
   $manage_persistence   = false,
   $slaveof              = undef,
-  String $version       = '3.2.3-1.el7',
   $packages             = ['redis'],
+  String $protected     = 'no',
   String $redis_conf    = '/etc/redis.conf',
   String $redis_service = 'redis',
+  String $version       = 'installed',
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version =~ "3.2" ) {
-    $config_32 = true
+  if ( $version =~ /^3.2.*/ ) or ( $version == 'installed' ) {
+    if ( $protected != "disabled" ) {
+      $config_32 = $protected
+    }
   }
 
   # Define the data directory with proper ownership if provided

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,24 +26,20 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis (
-  $config             = {},
-  $manage_persistence = false,
-  $slaveof            = undef,
-  $version            = 'installed',
-  $packages           = ['redis'],
-  $redis_conf         = '/etc/redis.conf',
-  $redis_service      = 'redis',
-  $version            = 'installed',
-  $packages           = ['redis'],
-  $redis_conf         = 'redis.conf',
-  $redis_service      = 'redis.service',
+  $config               = {},
+  $manage_persistence   = false,
+  $slaveof              = undef,
+  String $version       = '3.2.3-1.el7',
+  $packages             = ['redis'],
+  String $redis_conf    = '/etc/redis.conf',
+  String $redis_service = 'redis',
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version >= "3.2" ) or ( $version == "installed" ) {
+  if ( $version =~ "3.2" ) {
     $config_32 = true
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -30,7 +30,7 @@ class redis (
   $manage_persistence = false,
   $slaveof            = undef,
   $version            = 'installed',
-  $packages           = ['redis']
+  $packages           = ['redis'],
   $redis_conf         = 'redis.conf',
   $redis_service      = 'redis.service',
 ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,8 +12,9 @@
 # $redis_conf: The configuration file for redis
 # $redis_service: The serivce to run for redis
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
-# or specifically bind to an address, you can use disabled here if your
-# version is "installed" or you use the "bind" parameter in the config file.
+# or specifically bind to an address, if you are using an earlier
+# version of redis and "installed" as your version you can use "protected = disabled"
+# to make sure the option protected-mode is not added to the configuration fie.
 #
 # === Examples
 #
@@ -42,7 +43,7 @@ class redis (
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
-  # We need to see what version is in use to see if protected-mode should be set.
+  # See if protected-mode should be set.
   if ( versioncmp( $version, '3.2' ) >= 0 ) or ( $version == 'installed' ) {
     if ( $protected != "disabled" ) {
       $config_32 = $protected

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,7 @@
 # $redis_service: The serivce to run for redis
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
 # or specifically bind to an address, you can use disabled here if your
-# versions is "installed"
+# version is "installed" or you use the "bind" parameter in the config file.
 #
 # === Examples
 #

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -9,8 +9,8 @@
 # $sentinel_service - The service to run for sentinel
 # that sentinel should watch.
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
-# or specifically bind to an address, you can use disabled here if
-# your versions is installed.
+# or specifically bind to an address, you can use "disabled" here if
+# your version is "installed" or you use the "bind" parameter in the config file.
 #
 # === Examples
 #

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -6,7 +6,7 @@
 #
 # $redis_clusters - This is a hash that defines the redis clusters
 # $sentinel_conf - The configuration file to read for sentinel
-# $sentinel_service - The service to run for sentinel
+# $service_name - The service to run for sentinel
 # that sentinel should watch.
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
 # or specifically bind to an address, if you are using an earlier
@@ -34,7 +34,7 @@
 class redis::sentinel (
   $redis_clusters          = undef,
   String $sentinel_conf    = '/etc/sentinel.conf',
-  String $sentinel_service = 'sentinel',
+  String $service_name     = 'sentinel',
   $packages                = ['redis'],
   String $protected        = 'no',
   String $version          = 'installed',
@@ -73,12 +73,12 @@ class redis::sentinel (
   exec { 'cp_sentinel_conf':
     command => "/bin/cp ${sentinel_conf}.puppet ${sentinel_conf} && /bin/touch ${sentinel_conf}.copied",
     creates => "${sentinel_conf}.copied",
-    notify  => Service[$sentinel_service],
+    notify  => Service[$service_name],
     require => File["${sentinel_conf}.puppet"],
   }
 
   # Run it!
-  service { $sentinel_service:
+  service { $service_name:
     ensure     => running,
     enable     => true,
     hasrestart => true,
@@ -103,7 +103,7 @@ class redis::sentinel (
   exec { 'configure_sentinel':
     command     => $config_script,
     refreshonly => true,
-    require     => [ Service[$sentinel_service], File[$config_script] ],
+    require     => [ Service[$service_name], File[$config_script] ],
   }
 
 }

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -31,8 +31,8 @@ class redis::sentinel (
   $version          = 'installed',
   $redis_clusters   = undef,
   $packages         = $redis::packages,
-  $sentinel_conf    = undef,
-  $sentinel_service = undef,
+  $sentinel_conf    = 'sentinel.conf',
+  $sentinel_service = 'sentinel.service',
 ) {
 
   # Install the redis package

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -28,7 +28,7 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis::sentinel (
-  $version          = 'redis-3.0.5-1.el7.cmm.x86_64',
+  $version          = 'installed',
   $redis_clusters   = undef,
   $sentinel_conf    = '/etc/sentinel.conf',
   $sentinel_service = 'sentinel',

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -38,6 +38,10 @@ class redis::sentinel (
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
+  if ( $version >= "3.2" ) or ( $version == "installed" ) {
+    $config_32 = true
+  }
+
   # Declare $sentinel_conf here so we can manage ownership
   file { $sentinel_conf:
     ensure  => present,
@@ -60,7 +64,7 @@ class redis::sentinel (
 
   exec { 'cp_sentinel_conf':
     command => "/bin/cp ${sentinel_conf}.puppet ${sentinel_conf} && /bin/touch ${sentinel_conf}.copied",
-    creates => "/etc/${sentinel_conf}.copied",
+    creates => "${sentinel_conf}.copied",
     notify  => Service[$sentinel_service],
     require => File["${sentinel_conf}.puppet"],
   }

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -30,16 +30,16 @@
 class redis::sentinel (
   $version          = 'installed',
   $redis_clusters   = undef,
-  $packages         = $redis::packages,
-  $sentinel_conf    = 'sentinel.conf',
-  $sentinel_service = 'sentinel.service',
+  $sentinel_conf    = '/etc/sentinel.conf',
+  $sentinel_service = 'sentinel',
+  $packages         = ['redis'],
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
-  # Declare /etc/[sentinel_conf] here so we can manage ownership
-  file { "/etc/${sentinel_conf}":
+  # Declare $sentinel_conf here so we can manage ownership
+  file { $sentinel_conf:
     ensure  => present,
     owner   => 'redis',
     group   => 'root',
@@ -49,7 +49,7 @@ class redis::sentinel (
   # Sentinel rewrites its config file so we lay this one down initially.
   # This allows us to manage the configuration file upon installation
   # and then never again.
-  file { "/etc/${sentinel_conf}.puppet":
+  file { "${sentinel_conf}.puppet":
     ensure  => present,
     owner   => 'redis',
     group   => 'root',
@@ -59,10 +59,10 @@ class redis::sentinel (
   }
 
   exec { 'cp_sentinel_conf':
-    command => "/bin/cp /etc/${sentinel_conf}.puppet /etc/${sentinel_conf} && /bin/touch /etc/${sentinel_conf}.copied",
+    command => "/bin/cp ${sentinel_conf}.puppet ${sentinel_conf} && /bin/touch ${sentinel_conf}.copied",
     creates => "/etc/${sentinel_conf}.copied",
     notify  => Service[$sentinel_service],
-    require => File["/etc/${sentinel_conf}.puppet"],
+    require => File["${sentinel_conf}.puppet"],
   }
 
   # Run it!

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -9,8 +9,9 @@
 # $sentinel_service - The service to run for sentinel
 # that sentinel should watch.
 # $protected - As of version 3.2 you need to set proteced-mode yes or no
-# or specifically bind to an address, you can use "disabled" here if
-# your version is "installed" or you use the "bind" parameter in the config file.
+# or specifically bind to an address, if you are using an earlier
+# version of redis and "installed" as your version you can use "protected = disabled"
+# to make sure the option protected-mode is not added to the configuration fie.
 #
 # === Examples
 #
@@ -42,7 +43,7 @@ class redis::sentinel (
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
-  # We need to see what version is in use to see if protected-mode should be set.
+  # See if protected-mode should be set.
   if ( versioncmp( $version, '3.2' ) >= 0 ) or ( $version == 'installed' ) {
     if ( $protected != "disabled" ) {
       $config_32 = $protected

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -43,7 +43,7 @@ class redis::sentinel (
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version =~ /^3.2.*/ ) or ( $version == 'installed' ) {
+  if ( versioncmp( $version, '3.2' ) >= 0 ) or ( $version == 'installed' ) {
     if ( $protected != "disabled" ) {
       $config_32 = $protected
     }

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -28,7 +28,7 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis::sentinel (
-  $version          = 'installed',
+  $version          = 'redis-3.0.5-1.el7.cmm.x86_64',
   $redis_clusters   = undef,
   $sentinel_conf    = '/etc/sentinel.conf',
   $sentinel_service = 'sentinel',

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -5,6 +5,8 @@
 # === Parameters
 #
 # $redis_clusters - This is a hash that defines the redis clusters
+# $sentinel_conf - The configuration file to read for sentinel
+# $sentinel_service - The service to run for sentinel
 # that sentinel should watch.
 #
 # === Examples
@@ -26,16 +28,23 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis::sentinel (
-  $version        = 'installed',
-  $redis_clusters = undef,
-  $packages       = $redis::packages,
+  $version          = 'installed',
+  $redis_clusters   = undef,
+  $sentinel_conf    = '/etc/sentinel.conf',
+  $sentinel_service = 'sentinel',
+  $packages         = ['redis'],
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
-  # Declare /etc/sentinel.conf here so we can manage ownership
-  file { '/etc/sentinel.conf':
+  # We need to see what version is in use to see if protected-mode should be set.
+  if ( $version >= "3.2" ) or ( $version == "installed" ) {
+    $config_32 = true
+  }
+
+  # Declare $sentinel_conf here so we can manage ownership
+  file { $sentinel_conf:
     ensure  => present,
     owner   => 'redis',
     group   => 'root',
@@ -45,7 +54,7 @@ class redis::sentinel (
   # Sentinel rewrites its config file so we lay this one down initially.
   # This allows us to manage the configuration file upon installation
   # and then never again.
-  file { '/etc/sentinel.conf.puppet':
+  file { "${sentinel_conf}.puppet":
     ensure  => present,
     owner   => 'redis',
     group   => 'root',
@@ -55,14 +64,14 @@ class redis::sentinel (
   }
 
   exec { 'cp_sentinel_conf':
-    command => '/bin/cp /etc/sentinel.conf.puppet /etc/sentinel.conf && /bin/touch /etc/sentinel.conf.copied',
-    creates => '/etc/sentinel.conf.copied',
-    notify  => Service['sentinel'],
-    require => File['/etc/sentinel.conf.puppet'],
+    command => "/bin/cp ${sentinel_conf}.puppet ${sentinel_conf} && /bin/touch ${sentinel_conf}.copied",
+    creates => "${sentinel_conf}.copied",
+    notify  => Service[$sentinel_service],
+    require => File["${sentinel_conf}.puppet"],
   }
 
   # Run it!
-  service { 'sentinel':
+  service { $sentinel_service:
     ensure     => running,
     enable     => true,
     hasrestart => true,
@@ -87,7 +96,7 @@ class redis::sentinel (
   exec { 'configure_sentinel':
     command     => $config_script,
     refreshonly => true,
-    require     => [ Service['sentinel'], File[$config_script] ],
+    require     => [ Service[$sentinel_service], File[$config_script] ],
   }
 
 }

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -8,6 +8,9 @@
 # $sentinel_conf - The configuration file to read for sentinel
 # $sentinel_service - The service to run for sentinel
 # that sentinel should watch.
+# $protected - As of version 3.2 you need to set proteced-mode yes or no
+# or specifically bind to an address, you can use disabled here if
+# your versions is installed.
 #
 # === Examples
 #
@@ -28,19 +31,22 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis::sentinel (
-  String $version          = 'installed',
   $redis_clusters          = undef,
   String $sentinel_conf    = '/etc/sentinel.conf',
   String $sentinel_service = 'sentinel',
   $packages                = ['redis'],
+  String $protected        = 'no',
+  String $version          = 'installed',
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version =~ "3.2" ) {
-    $config_32 = true
+  if ( $version =~ /^3.2.*/ ) or ( $version == 'installed' ) {
+    if ( $protected != "disabled" ) {
+      $config_32 = $protected
+    }
   }
 
   # Declare $sentinel_conf here so we can manage ownership

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -28,18 +28,18 @@
 # Dan Sajner <dsajner@covermymeds.com>
 #
 class redis::sentinel (
-  $version          = 'installed',
-  $redis_clusters   = undef,
-  $sentinel_conf    = '/etc/sentinel.conf',
-  $sentinel_service = 'sentinel',
-  $packages         = ['redis'],
+  String $version          = 'installed',
+  $redis_clusters          = undef,
+  String $sentinel_conf    = '/etc/sentinel.conf',
+  String $sentinel_service = 'sentinel',
+  $packages                = ['redis'],
 ) {
 
   # Install the redis package
   ensure_packages($packages, { 'ensure' => $version })
 
   # We need to see what version is in use to see if protected-mode should be set.
-  if ( $version >= "3.2" ) or ( $version == "installed" ) {
+  if ( $version =~ "3.2" ) {
     $config_32 = true
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "covermymeds-redis",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "author": "CoverMyMeds",
   "license": "MIT",
   "summary": "Redis and Sentinel config management.",

--- a/templates/redis.conf.puppet.erb
+++ b/templates/redis.conf.puppet.erb
@@ -36,6 +36,8 @@
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
 daemonize yes
 
+protected-mode no
+
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
 pidfile /var/run/redis/redis.pid

--- a/templates/redis.conf.puppet.erb
+++ b/templates/redis.conf.puppet.erb
@@ -39,7 +39,7 @@ daemonize yes
 # proteced-mode defaults to yes and will only allow loop back connections unless
 # the bind parameter is used with specific IPs.
 <% if @config_32 -%>
-protected-mode no
+protected-mode <%= @protected -%>
 <% end -%>
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by

--- a/templates/redis.conf.puppet.erb
+++ b/templates/redis.conf.puppet.erb
@@ -36,6 +36,12 @@
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
 daemonize yes
 
+# proteced-mode defaults to yes and will only allow loop back connections unless
+# the bind parameter is used with specific IPs.
+<% if @config_32 -%>
+protected-mode no
+<% end -%>
+
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
 pidfile /var/run/redis/redis.pid

--- a/templates/redis.conf.puppet.erb
+++ b/templates/redis.conf.puppet.erb
@@ -37,7 +37,7 @@
 daemonize yes
 
 # proteced-mode defaults to yes and will only allow loop back connections unless
-# the bind parameter is used with specific IPs.
+# you bind to a specific IP.
 <% if @config_32 -%>
 protected-mode <%= @protected -%>
 <% end -%>

--- a/templates/sentinel.conf.erb
+++ b/templates/sentinel.conf.erb
@@ -17,6 +17,12 @@ port 26379
 # unmounting filesystems.
 dir /tmp
 
+# proteced-mode defaults to yes and will only allow loop back connections unless
+# the bind parameter is used with specific IPs.
+<% if @confi_32 -%>
+protected-mode no
+<% end -%>
+
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this master, and to consider it in O_DOWN

--- a/templates/sentinel.conf.erb
+++ b/templates/sentinel.conf.erb
@@ -18,7 +18,7 @@ port 26379
 dir /tmp
 
 # proteced-mode defaults to yes and will only allow loop back connections unless
-# the bind parameter is used with specific IPs.
+# you bind to a specific IP.
 <% if @config_32 -%>
 protected-mode <%= @protected -%>
 <% end -%>

--- a/templates/sentinel.conf.erb
+++ b/templates/sentinel.conf.erb
@@ -17,6 +17,10 @@ port 26379
 # unmounting filesystems.
 dir /tmp
 
+<% if @confi_32 -%>
+protected-mode no
+<% end -%>
+
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>
 #
 # Tells Sentinel to monitor this master, and to consider it in O_DOWN

--- a/templates/sentinel.conf.erb
+++ b/templates/sentinel.conf.erb
@@ -19,8 +19,8 @@ dir /tmp
 
 # proteced-mode defaults to yes and will only allow loop back connections unless
 # the bind parameter is used with specific IPs.
-<% if @confi_32 -%>
-protected-mode no
+<% if @config_32 -%>
+protected-mode <%= @protected -%>
 <% end -%>
 
 # sentinel monitor <master-name> <ip> <redis-port> <quorum>


### PR DESCRIPTION
These change will help move to the EPEL maintained redis package, and also enable a bit more flexibility for configuring redis and sentinel.

The service name and configuration file name for sentinel change when using the EPEL package.  The configuration file becomes 'redis-sentinel.conf' and the service for systemd is also prefixed with redis.